### PR TITLE
Suffix menus with (NEW) (RDEV-7047) 

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ class ShotgunPanelApp(Application):
         # also register a menu entry on the shotgun menu so that users
         # can launch the panel
         self.engine.register_command(
-            "Shotgun Panel...",
+            "Shotgun Panel... (NEW)",
             self.create_panel,
             {
                 "type": "panel",

--- a/info.yml
+++ b/info.yml
@@ -70,7 +70,7 @@ supported_engines:
 requires_shotgun_fields:
         
 # More verbose description of this item 
-display_name: "Shotgun Panel"
+display_name: "Shotgun Panel (NEW)"
 description: "Panel UI with Shotgun information about your scene, yourself and the things around you."
 
 # Required minimum versions for this item to run


### PR DESCRIPTION
To accommodate the users with the new app and to easily differentiate between the old app and the new app, I had to fork the app and add a `(NEW)` suffix in the Shotgun menu.

**This is temporary and will be removed after a couple of weeks**